### PR TITLE
Fix container naming when deploying

### DIFF
--- a/src/services/upload.service.ts
+++ b/src/services/upload.service.ts
@@ -20,7 +20,10 @@ export async function handleUpload(file: Express.Multer.File): Promise<{ url: st
   await buildDockerImage(imageName, projectPath);
 
   // 5️⃣ Run contenedor con Traefik
-  await runAppWithTraefik(imageName, projectName, projectName); // de momento sin env
+  // NOTE: runAppWithTraefik expects (appName, imageName, subdomain)
+  // appName should be the project name (used for container name),
+  // imageName is the docker image built above.
+  await runAppWithTraefik(projectName, imageName, projectName); // de momento sin env
 
   // 6️⃣ Registrar app
   const newApp: AppRegistryEntry = {


### PR DESCRIPTION
## Summary
- fix argument order when calling `runAppWithTraefik`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602b2aa4bc83259f6ce6f86a9a9d8b